### PR TITLE
Remove un-necessary info from GPL-v3 license

### DIFF
--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -94,18 +94,4 @@ GNU GENERAL PUBLIC LICENSE
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
 {% endif %}


### PR DESCRIPTION
Cleanup GPLV3 mentioned in #24. Grabbed directly from the `How to Apply These Terms to Your New Programs` from the [official GNU site](https://www.gnu.org/licenses/gpl-3.0.en.html)